### PR TITLE
change QPS threshold and failed RPS key updated

### DIFF
--- a/server/pkg/clients/http.go
+++ b/server/pkg/clients/http.go
@@ -132,7 +132,7 @@ func (h *HttpClient) Manager(ctx context.Context, conf models.Request, done chan
 	numOfClient := conf.Clients
 	var throttle <-chan time.Time
 	if conf.QPS > 0 {
-		throttle = time.Tick(time.Duration(1e6/conf.QPS) * time.Microsecond)
+		throttle = time.Tick(time.Duration(1e6/conf.QPS+1) * time.Microsecond)
 	}
 	var wg sync.WaitGroup
 	wg.Add(numOfClient)

--- a/server/pkg/utils/client.go
+++ b/server/pkg/utils/client.go
@@ -21,7 +21,7 @@ func init() {
 	}
 	httpClient = &http.Client{
 		Transport: tr,
-		Timeout:   time.Second * 2,
+		Timeout:   time.Second * 5,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/server/pkg/utils/loadster.go
+++ b/server/pkg/utils/loadster.go
@@ -140,7 +140,7 @@ func calculatePercentage(total int64, amount int64) int {
 }
 
 func calculateRpsForEachLoad(load models.Loadster) int64 {
-	endTime := load.Created
+	endTime := load.CreatedAt
 	startTime := load.StartTime
 	if load.Count > 0 && ((endTime-startTime)/1000) > 0 {
 		return (load.Count / ((endTime - startTime) / 1000))

--- a/ui/src/pages/Dashboard/LoadRequest/RequestedStats/index.tsx
+++ b/ui/src/pages/Dashboard/LoadRequest/RequestedStats/index.tsx
@@ -83,7 +83,7 @@ export default function RequestStats() {
         />
         <Stats
           state={STATE.NAGATIVE}
-          value={loadsterRespons?.failRPS || 0}
+          value={loadsterRespons?.totalFailRPS || 0}
           text="Failed RPS"
         />
       </Box>


### PR DESCRIPTION
### Bug Fixes

- Add <= for QPS
- failed request RPS key updated to `totalFailRPS`
- RPS calculation was failed due to incorrect date selection fixed